### PR TITLE
Added script to generate compilation databases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .clwb/
 bazel-*
+compile_commands.json

--- a/README.md
+++ b/README.md
@@ -30,3 +30,17 @@ Should be preinstalled. Version should be gcc 8. Needs to support C++17.
 Things you may want to modify on the VM:
 * Enable ideavim
 
+# Other (unsupported) options
+
+## Using Clang-Tools outside of CLion
+
+To use tools such as `clang-tidy`, `clang-format` outside of CLion, 
+or to use alternative IDEs relying on tools such as `clangd` or `rtags`, 
+you will need a compilation database. To set one up, just run
+
+    ./gen_compile_commands.sh
+
+from inside the repository directory,
+which should result in a `compile_commands.json` file in the root of the project.
+
+This should work on most POSIX systems, but it needs bash to run.

--- a/gen_compile_commands.sh
+++ b/gen_compile_commands.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+RELEASE_VERSION=0.3.4
+DIRECTORY=./bazel-compilation-database-${RELEASE_VERSION}
+OPTS="--show_progress --show_loading_progress"
+
+# download compilation database generator if necessary
+if [ ! -d "$DIRECTORY" ]; then
+    curl -L https://github.com/grailbio/bazel-compilation-database/archive/${RELEASE_VERSION}.tar.gz | tar -xz
+fi
+
+# generate the compilation database
+if command -v clang >/dev/null 2>&1; then
+    # clang is most useful (clang-tools, clangd etc.) so default to that compiler's flags
+    CC=clang ./bazel-compilation-database-${RELEASE_VERSION}/generate.sh ${OPTS}
+else
+    # clang is not installed; just in case, though, we'll
+    # ignore GCC specific warnings so clang-tidy and such can run
+    ./bazel-compilation-database-${RELEASE_VERSION}/generate.sh ${OPTS} --copt=-Wno-unknown-warning-option
+    # remove -fno-canonical-system-headers, as this is unrecognised by clang-tools
+    # could replace with -no-canonical-prefixes for clang support, but seems to work regardless
+    sed -i -E 's/\s+-fno-canonical-system-headers\b//g' compile_commands.json
+fi


### PR DESCRIPTION
This is useful for things such as:

- using clang-tidy or clang-format from the command line
- emacs (rtags, or clangd as well)
- vim (youcompleteme, clangd...)
- using an IDE with no bazel support but LSP support

Could be useful for using more recent versions of CLion that aren't supported by the bazel plugin, if wanted.