### PR TITLE
Allow depreciated bazel depset ops to be used

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
-build --copt='-Werror' --copt='-pedantic' --copt='-Wall' --copt='-Wextra' --copt='-std=c++17'
+build --copt='-Werror' --copt='-pedantic' --copt='-Wall' --copt='-Wextra' --copt='-std=c++17' --incompatible_depset_union=false
 test --test_output=errors


### PR DESCRIPTION
See https://github.com/bazelbuild/intellij/issues/445

The bazel build in gen_compile_commands.sh uses + to add to depsets
which was apparently depreciated with newer releases.

Original error:

```
ERROR: /Users/careyli/unsw/comp6771/lectures/week1/BUILD:8:1: in //bazel-compilation-database-0.3.4:aspects.bzl%compilation_database_aspect aspect on cc_binary rule //lectures/week1:factorial:
Traceback (most recent call last):
        File "/Users/careyli/unsw/comp6771/lectures/week1/BUILD", line 8
                //bazel-compilation-database-0.3.4:aspects.bzl%compilation_database_aspect(...)
        File "/Users/careyli/unsw/comp6771/bazel-compilation-database-0.3.4/aspects.bzl", line 185, in _compilation_database_aspect_impl
                compilation_db += dep[CompilationAspect].compilation_db
`+` operator on a depset is forbidden. See https://docs.bazel.build/versions/master/skylark/depsets.html for recommendations. Use --incompatible_depset_union=false to temporarily disable this check.
ERROR: Analysis of aspect '//bazel-compilation-database-0.3.4:aspects.bzl%compilation_database_aspect of //lectures/week1:factorial' failed; build aborted: Analysis of target '//lectures/week1:factorial' failed; build aborted
INFO: Elapsed time: 1.062s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (20 packages loaded, 618 targets configured)
```

Bazel version:

```
Build label: 0.26.1-homebrew
Build target: bazel-out/darwin-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Thu Jun 6 18:36:29 2019 (1559846189)
Build timestamp: 1559846189
Build timestamp as int: 1559846189
```