### PR TITLE
Prevent running cpplint.py with Python 3

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -53,6 +53,11 @@ import sys
 import sysconfig
 import unicodedata
 
+if sys.version_info[0] != 2:
+    sys.stderr.write("cpplint.py needs to be run with Python 2, try running "
+                     "'python2 %s' instead\n" % sys.argv[0])
+    sys.exit(1)
+
 try:
   xrange          # Python 2
 except NameError:


### PR DESCRIPTION
cpplint doesn't work properly with Python 3, it just exits (successful)
without print anything. This should prevent students from thinking it
passed when it actually didn't run at all.

(This happened to me.)