### PR TITLE
Bump bazel-compilation-database version

### DIFF
--- a/gen_compile_commands.sh
+++ b/gen_compile_commands.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-RELEASE_VERSION=0.3.4
+RELEASE_VERSION=0.3.5
 DIRECTORY=./bazel-compilation-database-${RELEASE_VERSION}
 OPTS="--show_progress --show_loading_progress"
 


### PR DESCRIPTION
bazel-compilation-database v0.3.5 fixes compat issue with bazel 0.27.0.

See https://github.com/grailbio/bazel-compilation-database/commit/0a237db850968ebb41e585978e56805f9f265edf and https://github.com/grailbio/bazel-compilation-database/commit/cff40ea14e907af686166ed6ab723d6e018c161b